### PR TITLE
Poet dbtablenames

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
   - phpenv config-rm xdebug.ini
   - cd ../..
   - composer selfupdate
-  - composer create-project -n --no-dev moodlerooms/moodle-plugin-ci ci ^1
+  - composer create-project -n --no-dev --prefer-dist moodlerooms/moodle-plugin-ci ci dev-poet
   - export PATH="$(cd ci/bin; pwd):$(cd ci/vendor/bin; pwd):$PATH"
 
 install:
@@ -33,9 +33,11 @@ script:
   - moodle-plugin-ci phpcpd
   - moodle-plugin-ci phpmd
   - moodle-plugin-ci codechecker
+  - moodle-plugin-ci codechecker --standard poet
   - moodle-plugin-ci csslint
   - moodle-plugin-ci shifter
   - moodle-plugin-ci jshint
   - moodle-plugin-ci validate
   - moodle-plugin-ci phpunit
   - moodle-plugin-ci behat
+  - moodle-plugin-ci phpunit --coverage-text

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,41 @@
+language: php
+
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+php:
+ - 5.6
+ - 7.0
+
+env:
+ global:
+  - MOODLE_BRANCH=MOODLE_31_STABLE
+
+ matrix:
+  - DB=pgsql
+  - DB=mysqli
+
+before_install:
+  - phpenv config-rm xdebug.ini
+  - cd ../..
+  - composer selfupdate
+  - composer create-project -n --no-dev moodlerooms/moodle-plugin-ci ci ^1
+  - export PATH="$(cd ci/bin; pwd):$(cd ci/vendor/bin; pwd):$PATH"
+
+install:
+  - moodle-plugin-ci install
+
+script:
+  - moodle-plugin-ci phplint
+  - moodle-plugin-ci phpcpd
+  - moodle-plugin-ci phpmd
+  - moodle-plugin-ci codechecker
+  - moodle-plugin-ci csslint
+  - moodle-plugin-ci shifter
+  - moodle-plugin-ci jshint
+  - moodle-plugin-ci validate
+  - moodle-plugin-ci phpunit
+  - moodle-plugin-ci behat

--- a/classes/api/base.php
+++ b/classes/api/base.php
@@ -529,13 +529,13 @@ abstract class base {
         $newsection->course_id = $courseid;
         $newsection->section_id = $sectionid;
 
-        $section = $DB->get_record('onenote_user_sections', ['course_id' => $courseid, 'user_id' => $USER->id]);
+        $section = $DB->get_record('local_onenote_user_sections', ['course_id' => $courseid, 'user_id' => $USER->id]);
 
         if ($section) {
             $newsection->id = $section->id;
-            $update = $DB->update_record('onenote_user_sections', $newsection);
+            $update = $DB->update_record('local_onenote_user_sections', $newsection);
         } else {
-            $insert = $DB->insert_record('onenote_user_sections', $newsection);
+            $insert = $DB->insert_record('local_onenote_user_sections', $newsection);
         }
     }
 
@@ -740,7 +740,7 @@ abstract class base {
         }
 
         // If the page and corresponding db record already exist just return the URL.
-        $pagerecord = $DB->get_record('onenote_assign_pages', ['assign_id' => $assign->id, 'user_id' => $student->id]);
+        $pagerecord = $DB->get_record('local_onenote_assign_pages', ['assign_id' => $assign->id, 'user_id' => $student->id]);
         if (!empty($pagerecord)) {
             if (!empty($pagerecord->$requestedpageidfield)) {
                 try {
@@ -771,13 +771,13 @@ abstract class base {
 
             // User likely deleted the page. Update the db record to reflect it and recreate the page below.
             $pagerecord->$requestedpageidfield = null;
-            $DB->update_record('onenote_assign_pages', $pagerecord);
+            $DB->update_record('local_onenote_assign_pages', $pagerecord);
         } else {
             // Prepare record object since we will use it further down to insert into database.
             $pagerecord = new \stdClass;
             $pagerecord->assign_id = $assign->id;
             $pagerecord->user_id = $student->id;
-            $pagerecord->id = $DB->insert_record('onenote_assign_pages', $pagerecord);
+            $pagerecord->id = $DB->insert_record('local_onenote_assign_pages', $pagerecord);
         }
 
         // Get the section id for the course so we can create the page in the approp section.
@@ -822,7 +822,7 @@ abstract class base {
             $pagerecord->teacher_lastviewed = strtotime($response->lastModifiedTime);
             $pagerecord->teacher_lastviewed = empty($pagerecord->teacher_lastviewed) ? null : $pagerecord->teacher_lastviewed;
         }
-        $DB->update_record('onenote_assign_pages', $pagerecord);
+        $DB->update_record('local_onenote_assign_pages', $pagerecord);
 
         return $response->links->oneNoteWebUrl->href;
     }
@@ -838,7 +838,7 @@ abstract class base {
     protected function get_section($courseid, $userid) {
         global $DB;
 
-        $section = $DB->get_record('onenote_user_sections', ['course_id' => $courseid, 'user_id' => $userid]);
+        $section = $DB->get_record('local_onenote_user_sections', ['course_id' => $courseid, 'user_id' => $userid]);
 
         // Need to make sure section actually exists in case user may have deleted it.
         if ($section && $section->section_id) {
@@ -855,7 +855,7 @@ abstract class base {
 
         $this->sync_notebook_data();
 
-        $section = $DB->get_record('onenote_user_sections', ['course_id' => $courseid, 'user_id' => $userid]);
+        $section = $DB->get_record('local_onenote_user_sections', ['course_id' => $courseid, 'user_id' => $userid]);
         if ($section && $section->section_id) {
             return $section;
         }

--- a/db/install.xml
+++ b/db/install.xml
@@ -4,7 +4,7 @@
     xsi:noNamespaceSchemaLocation="../../../lib/xmldb/xmldb.xsd"
 >
   <TABLES>
-    <TABLE NAME="onenote_user_sections" COMMENT="to store OneNote section id's for each user for each course">
+    <TABLE NAME="local_onenote_user_sections" COMMENT="to store OneNote section id's for each user for each course">
       <FIELDS>
         <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
         <FIELD NAME="user_id" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="user id"/>
@@ -15,7 +15,7 @@
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
       </KEYS>
     </TABLE>
-    <TABLE NAME="onenote_assign_pages" COMMENT="to store OneNote page id's for submissions and fedbacks for student's assignments">
+    <TABLE NAME="local_onenote_assign_pages" COMMENT="to store OneNote page id's for submissions and fedbacks for student's assignments">
       <FIELDS>
         <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
         <FIELD NAME="user_id" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="user id"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -96,5 +96,20 @@ function xmldb_local_onenote_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2015111905, 'local', 'onenote');
     }
 
+    if ($oldversion < 2016062002) {
+        // Define table to be renamed.
+        $table = new xmldb_table('onenote_user_sections');
+        // Rename the table to use the correct Moodle naming convention.
+        $dbman->rename_table($table, 'local_onenote_user_sections');
+
+        // Define table to be renamed.
+        $table = new xmldb_table('onenote_assign_pages');
+        // Rename the table to use the correct Moodle naming convention.
+        $dbman->rename_table($table, 'local_onenote_assign_pages');
+
+        // Onenote savepoint reached.
+        upgrade_plugin_savepoint(true, 2016062002, 'local', 'onenote');
+    }
+
     return true;
 }

--- a/tests/onenoteapi_test.php
+++ b/tests/onenoteapi_test.php
@@ -316,7 +316,7 @@ class local_onenote_onenoteapi_testcase extends advanced_testcase {
         $createsubmission = $this->create_submission_feedback($this->cm, false, false, null, null, null);
         $this->submission = $this->assign->get_user_submission($this->user1->id, true);
 
-        $record = $DB->get_record('onenote_assign_pages',
+        $record = $DB->get_record('local_onenote_assign_pages',
                 array("assign_id" => $this->submission->assignment, "user_id" => $this->submission->userid));
 
         $tempfolder = $this->onenoteapi->create_temp_folder();

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2016062001;
+$plugin->version = 2016062002;
 $plugin->requires = 2016052300;
 $plugin->component = 'local_onenote';
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
This change will make the table names of the plugin comply with Moodle standards, and pass the automated plugin validation tests. The Travis file included is not required, but can generate test results like - https://travis-ci.org/POETGroup/moodle-local_onenote/builds/153373167